### PR TITLE
fix ApplicationDbContext initialized x 2

### DIFF
--- a/src/GovITHub.Auth.Common/Data/ApplicationDataInitializer.cs
+++ b/src/GovITHub.Auth.Common/Data/ApplicationDataInitializer.cs
@@ -9,11 +9,11 @@ namespace GovITHub.Auth.Common.Data
         public ApplicationDataInitializer(ApplicationDbContext ctx)
         {
             context = ctx;
-            context.Database.Migrate();
         }
 
         public void InitializeData()
         {
+            context.Database.Migrate();
         }
     }
 }

--- a/src/GovITHub.Auth.Common/Data/ApplicationDbContext.cs
+++ b/src/GovITHub.Auth.Common/Data/ApplicationDbContext.cs
@@ -12,7 +12,8 @@ namespace GovITHub.Auth.Common.Data
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
             : base(options)
         {
-            Database.EnsureCreated();
+            // commented due to ApplicationDataInitializer.InitializeData()
+            // Database.EnsureCreated();
         }
 
         protected override void OnModelCreating(ModelBuilder builder)


### PR DESCRIPTION
- add comment on ApplicationDbContext on Database.EnsureCreated
- ApplicationDataInitailizer.InitializeData() migrates the db context